### PR TITLE
Fix typo in test method name

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -39,7 +39,7 @@ class PostDetailTest(TestCase):
         "blog_system_db_data.json",
     ]
 
-    def test_post_detail_response_with_sorrect_template(self):
+    def test_post_detail_response_with_correct_template(self):
         response = self.client.get(reverse("blog:post-detail", args=[1]))
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Corrected the test method name from "test_post_detail_response_with_sorrect_template" to "test_post_detail_response_with_correct_template".
